### PR TITLE
blog: fix hunk-editing post's resulting diff

### DIFF
--- a/blag/content/blog/hunk_editing.markdown
+++ b/blag/content/blog/hunk_editing.markdown
@@ -228,8 +228,7 @@ following:
     # an opportunity to edit again. If all lines of the hunk are removed,
     # then the edit is aborted and the hunk is left unchanged.
 
-From here, we want to replace the leading minus of the change removal to a
-space and remove the last three additions.
+From here, we want to edit the diff to represent only what we care about.
 
 That is, we want the diff to look like:
 
@@ -238,8 +237,8 @@ That is, we want the diff to look like:
 
        defp _sort([]), do: []
     -  defp _sort(list = [h|t]) do
-     sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))
     +  defp _sort(list = [h|_]) do
+     sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))
        end
 
      end
@@ -257,8 +256,8 @@ can check the staged changes via `git-diff`:
 
        defp _sort([]), do: []
     -  defp _sort(list = [h|t]) do
-         _sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))
     +  defp _sort(list = [h|_]) do
+         _sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))
        end
 
      end


### PR DESCRIPTION
The diff hunk produced by this blog post's instructions is incorrect; when
applied to the original file, it produces the following:

~~~
defmodule Quicksort do

  def sort(list) do
    _sort(list)
  end

  defp _sort([]), do: []
    _sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))
  defp _sort(list = [h|_]) do
  end

end
~~~

I performed the minimum viable edit to make the post _accurate_, without
putting words in your mouth, but I believe that the current result with my
edits ends up being rather hand-wavy and could use a little more context.

My process for resolving the stated problem would be something like:

First, I would begin with the stated diff:

~~~ diff
# Manual hunk edit mode -- see bottom for a quick guide
@@ -5,8 +5,10 @@ defmodule Quicksort do
   end

   defp _sort([]), do: []
-  defp _sort(list = [h|t]) do
-    _sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))
+  defp _sort(list = [h|_]) do
+    (list |> Enum.filter(&(&1 < h)) |> _sort)
+    ++ [h] ++
+    (list |> Enum.filter(&(&1 > h)) |> _sort)
   end

 end
# ---
# To remove '-' lines, make them ' ' lines (context).
# To remove '+' lines, delete them.
# Lines starting with # will be removed.
#
# If the patch applies cleanly, the edited hunk will immediately be
# marked for staging. If it does not apply cleanly, you will be given
# an opportunity to edit again. If all lines of the hunk are removed,
# then the edit is aborted and the hunk is left unchanged.
~~~

Next, I would perform a net-zero-change rearrangement of the diff according
to the following rules, in order to add clarity:
 - a line beginning with a `+` can be moved up or down, so long as it does not
   cross a line beginning with a `-` or a ` `;
 - similarly, a line beginning with a `-` can be moved in either direction, so
   long as it does not cross a line beginning with a `+` or a ` `.

In this case, I would move the `+  defp _sort(list = [h|_]) do` line up, across
the `-    _sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))`
line:

~~~ diff
# Manual hunk edit mode -- see bottom for a quick guide
@@ -5,8 +5,10 @@ defmodule Quicksort do
   end

   defp _sort([]), do: []
-  defp _sort(list = [h|t]) do
+  defp _sort(list = [h|_]) do
-    _sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))
+    (list |> Enum.filter(&(&1 < h)) |> _sort)
+    ++ [h] ++
+    (list |> Enum.filter(&(&1 > h)) |> _sort)
   end

 end
# ---
# To remove '-' lines, make them ' ' lines (context).
# To remove '+' lines, delete them.
# Lines starting with # will be removed.
#
# If the patch applies cleanly, the edited hunk will immediately be
# marked for staging. If it does not apply cleanly, you will be given
# an opportunity to edit again. If all lines of the hunk are removed,
# then the edit is aborted and the hunk is left unchanged.
~~~

Finally, I would manually back out the bit of the diff I don't want, by
changing the leading `-` to a space ` ` and removing the related additions:

~~~ diff
# Manual hunk edit mode -- see bottom for a quick guide
@@ -5,8 +5,10 @@ defmodule Quicksort do
   end

   defp _sort([]), do: []
-  defp _sort(list = [h|t]) do
+  defp _sort(list = [h|_]) do
     _sort(Enum.filter(list, &(&1 < h))) ++ [h] ++ _sort(Enum.filter(list, &(&1 > h)))
   end

 end
# ---
# To remove '-' lines, make them ' ' lines (context).
# To remove '+' lines, delete them.
# Lines starting with # will be removed.
#
# If the patch applies cleanly, the edited hunk will immediately be
# marked for staging. If it does not apply cleanly, you will be given
# an opportunity to edit again. If all lines of the hunk are removed,
# then the edit is aborted and the hunk is left unchanged.
~~~